### PR TITLE
Update to "Unknown" entry

### DIFF
--- a/Character/Character.nmm
+++ b/Character/Character.nmm
@@ -467,7 +467,7 @@ Level Cap / 10
 NEDU
 NULL
 
-Unknown
+Amiibo
 135
 1
 NEDU


### PR DESCRIPTION
Self explanatory, I guess.
This byte only serves to tell the game if the character is an amiibo or not. ( It also removes the blue shield icon )
